### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To install dependencies for PyKaldi and kaldi-model-server on Ubuntu do:
 
 ```bash
 # Ubuntu Linux
-sudo apt-get install portaudio19-dev redis-server autoconf automake cmake curl g++ git graphviz libatlas3-base libtool make pkg-config subversion unzip wget zlib1g-dev virtualenv
+sudo apt-get install portaudio19-dev redis-server autoconf automake cmake curl g++ git graphviz libatlas3-base libtool make pkg-config subversion unzip wget zlib1g-dev virtualenv python3-dev
 ```
 
 On a Mac:


### PR DESCRIPTION
Unter Ubuntu 20.04 wird python3-dev benötigt sonst lässt sich pyaudio nicht installieren.
Habe es mit Server und Desktop getestet.